### PR TITLE
Change env variables in config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -17,8 +17,8 @@ config :runner, :container_benchmars_output_path, "/var/bench"
 
 config :runner, :job_timeout, {:system, :integer, "JOB_TIMEOUT", 900_000}
 
-config :runner, :api_user, {:system, "RUNNER_API_USER"}
-config :runner, :api_key, {:system, "RUNNER_API_KEY"}
-config :runner, :api_url, {:system, "RUNNER_API_URL", ["https://api.elixirbench.org/runner-api"]}
+config :runner, :api_user, {:system, "RUNNER_API_USER", "test-runner"}
+config :runner, :api_key, {:system, "RUNNER_API_KEY", "test"}
+config :runner, :api_url, {:system, "RUNNER_API_URL", "https://api.elixirbench.org/runner-api"}
 
 config :logger, level: :info


### PR DESCRIPTION
- Fixed default value for RUNNER_API_URL
- Added default values for RUNNER_API_USER and RUNNER_API_KEY according to values
included in seed.exs from the api-server repository.