### PR TITLE
run mix deps.compile before mix compile on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - MIX_ENV=test RUNNER_API_USER=test-runner RUNNER_API_KEY=test RUNNER_API_URL=http://localhost.com:4000/runner-api
 
 before_script:
+  - mix deps.compile
   - mix compile --warnings-as-errors
 
 script:


### PR DESCRIPTION
This PR adds ```mix deps.compile``` to run before ```mix compile --warnings-as-errors``` on travis.yml. Fix https://github.com/elixir-bench/elixir-bench-runner/issues/17.