### PR TITLE
Make image repository overridable with env var

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -21,4 +21,6 @@ config :runner, :api_user, {:system, "RUNNER_API_USER", "test-runner"}
 config :runner, :api_key, {:system, "RUNNER_API_KEY", "test"}
 config :runner, :api_url, {:system, "RUNNER_API_URL", "https://api.elixirbench.org/runner-api"}
 
+config :runner, :image_repository, {:system, "IMAGE_REPOSITORY", "elixirbench"}
+
 config :logger, level: :info

--- a/lib/runner/job.ex
+++ b/lib/runner/job.ex
@@ -115,9 +115,12 @@ defmodule ElixirBench.Runner.Job do
     container_benchmarks_output_path =
       Confex.fetch_env!(:runner, :container_benchmarks_output_path)
 
+    image_repository = Confex.fetch_env!(:runner, :image_repository)
+
     %{
       network_mode: @network_mode,
-      image: "elixirbench/runner:#{job.config.elixir_version}-#{job.config.erlang_version}",
+      image:
+        "#{image_repository}/runner:#{job.config.elixir_version}-#{job.config.erlang_version}",
       volumes: ["#{get_benchmarks_output_path(job)}:#{container_benchmarks_output_path}:Z"],
       depends_on: Map.keys(deps),
       environment: build_runner_environment(job),


### PR DESCRIPTION
Why:

* From #19:

  > We currently fetch direct from elixirbench account, this should be
    added as an environment variable.

This change addresses the need by:

* Changing the image repository from a hardcoded string to a
  configuration key which loads the value from an environment variable,
  using the old hardcoded value as the default.

This change closes #19.